### PR TITLE
Add xrf hdf5 exporter workflow

### DIFF
--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,6 +1,6 @@
 from prefect import task, flow, get_run_logger
 from data_validation import data_validation
-from exporter import exporter
+from xanes_exporter import xanes_exporter
 from xrf_hdf5_exporter import xrf_hdf5_exporter
 
 @task
@@ -13,6 +13,6 @@ def log_completion():
 def end_of_run_workflow(stop_doc):
     uid = stop_doc["run_start"]
     data_validation(uid, return_state=True)
-    exporter(uid)
+    xanes_exporter(uid)
     xrf_hdf5_exporter(uid)
     log_completion()

--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -1,7 +1,7 @@
 from prefect import task, flow, get_run_logger
 from data_validation import data_validation
 from exporter import exporter
-
+from xrf_hdf5_exporter import xrf_hdf5_exporter
 
 @task
 def log_completion():
@@ -14,4 +14,5 @@ def end_of_run_workflow(stop_doc):
     uid = stop_doc["run_start"]
     data_validation(uid, return_state=True)
     exporter(uid)
+    xrf_hdf5_exporter(uid)
     log_completion()

--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -225,7 +225,7 @@ def xanes_afterscan_plan(scanid):
 
 
 @flow(log_prints=True)
-def exporter(ref):
+def xanes_exporter(ref):
     logger = get_run_logger()
     logger.info("Start writing file...")
     xanes_afterscan_plan(ref)

--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -227,6 +227,7 @@ def xanes_afterscan_plan(scanid):
 @flow(log_prints=True)
 def xanes_exporter(ref):
     logger = get_run_logger()
-    logger.info("Start writing file...")
+    logger.info("Start writing file with xanes_exporter...")
     xanes_afterscan_plan(ref)
-    logger.info("Finish writing file.")
+    logger.info("Finish writing file with xanes_exporter.")
+

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -1,5 +1,7 @@
 from prefect import flow, task, get_run_logger
 
+CATALOG_NAME = "srx"
+
 ### Temporary solution until prefect deployment updates to 2024 environment ###
 ###############################################################################
 import sys
@@ -18,7 +20,7 @@ sys.path[:0] = overlay
 from tiled.client import from_profile
 from pyxrf.api import make_hdf
 
-tiled_client = from_profile("nsls2")["srx"]
+tiled_client = from_profile("nsls2")[CATALOG_NAME]
 tiled_client_raw = tiled_client["raw"]
 
 @task
@@ -50,7 +52,7 @@ def export_xrf_hdf5(scanid):
     prefix = "autorun_scan2D"
 
     logger.info(f"{working_dir =}")
-    make_hdf(scanid, wd=working_dir, prefix=prefix)
+    make_hdf(scanid, wd=working_dir, prefix=prefix, catalog_name=CATALOG_NAME)
 
 @flow(log_prints=True)
 def xrf_hdf5_exporter(scanid):

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -34,6 +34,14 @@ def export_xrf_hdf5(scanid):
         )
         return
 
+    # Check if this is an alignment scan
+    # scan_input array consists of [startx, stopx, number pts x, start y, stop y, num pts y, dwell]
+    if h.start["scan"]["scan_input"][5] == 1:
+        logger.info(
+            "This is likely an alignment scan. Not running pyxrf.api.make_hdf on this document."
+        )
+        return
+
     working_dir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}"  # noqa: E501
     prefix = "autorun_scan2D"
 

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -1,10 +1,9 @@
 from prefect import flow, task, get_run_logger
-from pyxrf.api import make_hdf
 
 ### Temporary solution until prefect deployment updates to 2024 environment ###
 ###############################################################################
 import sys
-conda_env = "2024-1.0-py310"
+conda_env = "2024-1.0-py310-tiled"
 python_ver = "python3.10"
 overlay = [
     f"/nsls2/data/srx/shared/config/bluesky_overlay/{conda_env}/lib/{python_ver}/site-packages",
@@ -17,6 +16,7 @@ sys.path[:0] = overlay
 ###############################################################################
 
 from tiled.client import from_profile
+from pyxrf.api import make_hdf
 
 tiled_client = from_profile("nsls2")["srx"]
 tiled_client_raw = tiled_client["raw"]

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -42,7 +42,11 @@ def export_xrf_hdf5(scanid):
         )
         return
 
-    working_dir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}"  # noqa: E501
+    if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
+        working_dir = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}"
+    else:
+        working_dir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}"  # noqa: E501
+
     prefix = "autorun_scan2D"
 
     logger.info(f"{working_dir =}")

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -1,0 +1,32 @@
+from prefect import flow, task, get_run_logger
+from tiled.client import from_profile
+from pyxrf.api import make_hdf
+
+tiled_client = from_profile("nsls2")["srx"]
+tiled_client_raw = tiled_client["raw"]
+
+@task
+def export(scanid):
+    logger = get_run_logger()
+
+    # Load header for our scan
+    h = tiled_client_raw[scanid]
+
+    if h.start["scan"]["type"] not in ["XRF_FLY", "XRF_STEP"]:
+        logger.info(
+            "Incorrect document type. Not running pyxrf.api.make_hdf on this document."
+        )
+        return
+
+    working_dir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}"  # noqa: E501
+    prefix = "autorun_scan2D"
+
+    logger.info(f"{working_dir =}")
+    make_hdf(scanid, wd=working_dir, prefix=prefix)
+
+@flow(log_prints=True)
+def xrf_hdf5_exporter(scanid):
+    logger = get_run_logger()
+    logger.info("Start writing file...")
+    export(scanid)
+    logger.info("Finish writing file.")

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -51,6 +51,6 @@ def export_xrf_hdf5(scanid):
 @flow(log_prints=True)
 def xrf_hdf5_exporter(scanid):
     logger = get_run_logger()
-    logger.info("Start writing file...")
+    logger.info("Start writing file with xrf_hdf5 exporter...")
     export_xrf_hdf5(scanid)
-    logger.info("Finish writing file.")
+    logger.info("Finish writing file with xrf_hdf5 exporter.")

--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -1,12 +1,28 @@
 from prefect import flow, task, get_run_logger
-from tiled.client import from_profile
 from pyxrf.api import make_hdf
+
+### Temporary solution until prefect deployment updates to 2024 environment ###
+###############################################################################
+import sys
+conda_env = "2024-1.0-py310"
+python_ver = "python3.10"
+overlay = [
+    f"/nsls2/data/srx/shared/config/bluesky_overlay/{conda_env}/lib/{python_ver}/site-packages",
+    f"/nsls2/conda/envs/{conda_env}/bin",
+    f"/nsls2/conda/envs/{conda_env}/lib/{python_ver}",
+    f"/nsls2/conda/envs/{conda_env}/lib/{python_ver}/lib-dynload",
+    f"/nsls2/conda/envs/{conda_env}/lib/{python_ver}/site-packages",
+]
+sys.path[:0] = overlay
+###############################################################################
+
+from tiled.client import from_profile
 
 tiled_client = from_profile("nsls2")["srx"]
 tiled_client_raw = tiled_client["raw"]
 
 @task
-def export(scanid):
+def export_xrf_hdf5(scanid):
     logger = get_run_logger()
 
     # Load header for our scan
@@ -28,5 +44,5 @@ def export(scanid):
 def xrf_hdf5_exporter(scanid):
     logger = get_run_logger()
     logger.info("Start writing file...")
-    export(scanid)
+    export_xrf_hdf5(scanid)
     logger.info("Finish writing file.")


### PR DESCRIPTION
This PR adds XRF hdf5 exporter to `end_of_run_workflow`. The original non-Prefect exporter is available [here](https://github.com/andrewmkiss/srx-autosave/blob/b32427b6caab360b82991138cc4061b028e16e6b/srx_autosave/api.py#L376-L440).