### PR TITLE
Change xanes exporter to read roinum from scan metadata

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -113,7 +113,7 @@ def xanes_textout(
 
 
 @task
-def xanes_afterscan_plan(scanid, roinum=None):
+def xanes_afterscan_plan(scanid):
     logger = get_run_logger()
 
     # Custom header list

--- a/exporter.py
+++ b/exporter.py
@@ -32,9 +32,9 @@ def xanes_textout(
 
     h = tiled_client_raw[scanid]
     if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
-        filepath = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/scan_{h.start['scan_id'    ]}_xanes.txt"
+        filepath = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"
     else:
-        filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['sca    n_id']}_xanes.txt"  # noqa: E501
+        filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"  # noqa: E501
 
     with open(filepath, "w") as f:
         dataset_client = h["primary"]["data"]

--- a/exporter.py
+++ b/exporter.py
@@ -113,7 +113,7 @@ def xanes_textout(
 
 
 @task
-def xanes_afterscan_plan(scanid, roinum=1):
+def xanes_afterscan_plan(scanid, roinum=None):
     logger = get_run_logger()
 
     # Custom header list
@@ -144,8 +144,10 @@ def xanes_afterscan_plan(scanid, roinum=1):
         raise KeyError("SRS not found in data!")
     # Include fluorescence data if present, allow multiple rois
     if "xs" in h.start["detectors"]:
-        if type(roinum) is not list:
-            roinum = [roinum]
+        if "ROI" in h.start["scan"].keys():
+            roinum = list(h.start["scan"]["ROI"])
+        else:
+            roinum = [1]  # if no ROI key found, assume ROI 1
         logger.info(roinum)
         for i in roinum:
             logger.info(f"Current roinumber: {i}")
@@ -223,5 +225,5 @@ def xanes_afterscan_plan(scanid, roinum=1):
 def exporter(ref):
     logger = get_run_logger()
     logger.info("Start writing file...")
-    xanes_afterscan_plan(ref, roinum=1)
+    xanes_afterscan_plan(ref)
     logger.info("Finish writing file.")

--- a/exporter.py
+++ b/exporter.py
@@ -31,7 +31,10 @@ def xanes_textout(
     """
 
     h = tiled_client_raw[scanid]
-    filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"  # noqa: E501
+    if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
+        filepath = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/scan_{h.start['scan_id'    ]}_xanes.txt"
+    else:
+        filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['sca    n_id']}_xanes.txt"  # noqa: E501
 
     with open(filepath, "w") as f:
         dataset_client = h["primary"]["data"]


### PR DESCRIPTION
Instead of predefining the ROI number, this will grab the ROI number(s) from the scan metadata