### PR TITLE
Migrate logscan_detailed method from profile_collection

### DIFF
--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -2,6 +2,7 @@ from prefect import task, flow, get_run_logger
 from data_validation import data_validation
 from xanes_exporter import xanes_exporter
 from xrf_hdf5_exporter import xrf_hdf5_exporter
+from logscan import logscan
 
 @task
 def log_completion():
@@ -15,4 +16,5 @@ def end_of_run_workflow(stop_doc):
     # data_validation(uid, return_state=True)
     xanes_exporter(uid)
     xrf_hdf5_exporter(uid)
+    logscan(uid)
     log_completion()

--- a/logscan.py
+++ b/logscan.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from prefect import flow, task, get_run_logger
 from tiled.client import from_profile
 
+
 tiled_client = from_profile("nsls2")["srx"]
 tiled_client_raw = tiled_client["raw"]
 
@@ -28,18 +29,18 @@ def logscan_detailed(scanid):
         userdatadir = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/"
     else:
         userdatadir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/"
-        
+
     if not Path(userdatadir).exist():
         logger.info(
             "Incorrect path. Check cycle and proposal id in document. Not running the logger on this document."
         )
         return
-    
+
     logfile_path = userdatadir + f"logfile{h.start['data_session']}.txt"
     is_scanid = False
     if Path(logfile_path).exists():
         is_scanid = find_scanid(logfile_path, h.start['scan_id'])
-    
+
     if not is_scanid:
         with open(logfile_path, "a") as userlogf:
             userlogf.write(str(h.start['scan_id']) + '\t' + str(h.start['uid']) + '\t' + str(h.start['scan']['type']) + '\t' + str(h.start['scan']['scan_input']) + '\n')

--- a/logscan.py
+++ b/logscan.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from prefect import flow, task, get_run_logger
+from tiled.client import from_profile
+
+tiled_client = from_profile("nsls2")["srx"]
+tiled_client_raw = tiled_client["raw"]
+
+
+def find_scanid(logfile_path, scanid):
+    is_scanid = False
+    with open(logfile_path) as lf:
+        lines = lf.readlines()
+        for line in lines:
+            params = line.strip().split("\t")
+            if int(params[0]) == scanid:
+                is_scanid = True
+                break
+    return is_scanid
+
+
+@task
+def logscan_detailed(scanid):
+    logger = get_run_logger()
+    
+    h = tiled_client_raw[scanid]
+    
+    if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
+        userdatadir = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/"
+    else:
+        userdatadir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/"
+        
+    if not Path(userdatadir).exist():
+        logger.info(
+            "Incorrect path. Check cycle and proposal id in document. Not running the logger on this document."
+        )
+        return
+    
+    logfile_path = userdatadir + f"logfile{h.start['data_session']}.txt"
+    is_scanid = False
+    if Path(logfile_path).exists():
+        is_scanid = find_scanid(logfile_path, h.start['scan_id'])
+    
+    if not is_scanid:
+        with open(logfile_path, "a") as userlogf:
+            userlogf.write(str(h.start['scan_id']) + '\t' + str(h.start['uid']) + '\t' + str(h.start['scan']['type']) + '\t' + str(h.start['scan']['scan_input']) + '\n')
+            logger.info(f"Added {h.start['scan_id']} to the logs")
+
+
+@flow(log_prints=True)
+def logscan(ref):
+    logger = get_run_logger()
+    logger.info("Start writing logfile...")
+    logscan_detailed(ref)
+    logger.info("Finish writing logfile.")

--- a/logscan.py
+++ b/logscan.py
@@ -10,8 +10,7 @@ tiled_client_raw = tiled_client["raw"]
 def find_scanid(logfile_path, scanid):
     is_scanid = False
     with open(logfile_path) as lf:
-        lines = lf.readlines()
-        for line in lines:
+        for line in lf:
             params = line.strip().split("\t")
             if int(params[0]) == scanid:
                 is_scanid = True
@@ -22,13 +21,20 @@ def find_scanid(logfile_path, scanid):
 @task
 def logscan_detailed(scanid):
     logger = get_run_logger()
-    
+
     h = tiled_client_raw[scanid]
-    
-    if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
-        userdatadir = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/"
+
+    if (
+        "SRX Beamline Commissioning".lower()
+        in h.start["proposal"]["proposal_title"].lower()
+    ):
+        userdatadir = (
+            f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/"
+        )
     else:
-        userdatadir = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/"
+        userdatadir = (
+            f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/"
+        )
 
     if not Path(userdatadir).exist():
         logger.info(
@@ -39,11 +45,20 @@ def logscan_detailed(scanid):
     logfile_path = userdatadir + f"logfile{h.start['data_session']}.txt"
     is_scanid = False
     if Path(logfile_path).exists():
-        is_scanid = find_scanid(logfile_path, h.start['scan_id'])
+        is_scanid = find_scanid(logfile_path, h.start["scan_id"])
 
     if not is_scanid:
         with open(logfile_path, "a") as userlogf:
-            userlogf.write(str(h.start['scan_id']) + '\t' + str(h.start['uid']) + '\t' + str(h.start['scan']['type']) + '\t' + str(h.start['scan']['scan_input']) + '\n')
+            userlogf.write(
+                str(h.start["scan_id"])
+                + "\t"
+                + str(h.start["uid"])
+                + "\t"
+                + str(h.start["scan"]["type"])
+                + "\t"
+                + str(h.start["scan"]["scan_input"])
+                + "\n"
+            )
             logger.info(f"Added {h.start['scan_id']} to the logs")
 
 

--- a/logscan.py
+++ b/logscan.py
@@ -25,8 +25,8 @@ def logscan_detailed(scanid):
     h = tiled_client_raw[scanid]
 
     if (
-        "SRX Beamline Commissioning".lower()
-        in h.start["proposal"]["proposal_title"].lower()
+        "Beamline Commissioning (beamline staff only)".lower()
+        in h.start["proposal"]["type"].lower()
     ):
         userdatadir = (
             f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/"


### PR DESCRIPTION
This PR attempts to automate the process of keeping track of the parameters run for each experiment inside a log file.
Previously, the `logscan_detailed` method had to be run after the experiment was finished manually.
The new implementation adds compatibility with prefect and tiled. And it includes the cycle and proposal criteria to save the information in the correct path which has been established by the data security project.