### PR TITLE
Change check by type instead of title

### DIFF
--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -31,7 +31,7 @@ def xanes_textout(
     """
 
     h = tiled_client_raw[scanid]
-    if "SRX Beamline Commissioning".lower() in h.start["proposal"]["proposal_title"].lower():
+    if "Beamline Commissioning (beamline staff only)".lower() in h.start["proposal"]["tyype"].lower():
         filepath = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"
     else:
         filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"  # noqa: E501

--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -31,7 +31,7 @@ def xanes_textout(
     """
 
     h = tiled_client_raw[scanid]
-    if "Beamline Commissioning (beamline staff only)".lower() in h.start["proposal"]["tyype"].lower():
+    if "Beamline Commissioning (beamline staff only)".lower() in h.start["proposal"]["type"].lower():
         filepath = f"/nsls2/data/srx/proposals/commissioning/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"
     else:
         filepath = f"/nsls2/data/srx/proposals/{h.start['cycle']}/{h.start['data_session']}/scan_{h.start['scan_id']}_xanes.txt"  # noqa: E501


### PR DESCRIPTION
This PR change the document check we were using by title because it can be easily modified by staff which could cause human error. We decided to use type instead which is a filed selected from the proposal form and the name never changes