### PR TITLE
Fix xrf step scans with 1 um step will now export

### DIFF
--- a/xrf_hdf5_exporter.py
+++ b/xrf_hdf5_exporter.py
@@ -40,7 +40,7 @@ def export_xrf_hdf5(scanid):
     # Check if this is an alignment scan
     # scan_input array consists of [startx, stopx, number pts x, start y, stop y, num pts y, dwell]
     idx_NUM_PTS_Y = 5
-    if h.start["scan"]["scan_input"][idx_NUM_PTS_Y] == 1:
+    if h.start["scan"]["type"] == "XRF_FLY" and h.start["scan"]["scan_input"][idx_NUM_PTS_Y] == 1:
         logger.info(
             "This is likely an alignment scan. Not running pyxrf.api.make_hdf on this document."
         )


### PR DESCRIPTION
With fly scans, the index 5 corresponds to number of steps. If this is one, it is likely an alignment scan so it should be disregarded.

If this is a step scan, the index 5 corresponds to the step size so a value of 1 means 1 um steps and it should still be exported.

This fix checks for the scan type and the value of the index to decide if it should be ignored.