### PR TITLE
Fix logscan so it works for all scans

### DIFF
--- a/logscan.py
+++ b/logscan.py
@@ -50,21 +50,22 @@ def logscan_detailed(scanid):
     if not is_scanid:
         # Let's build the string
         #   Each scan should have a scan ID and UID
-        out_str = f"{h.start["scan_id"]}\t{h.start["uid"]}"
+        out_str = f"{h.start['scan_id']}\t{h.start['uid']}"
         #   I don't think the "scan" dictionary is guaranteed with each scan
         #   I think this is SRX-custom-scan specific
         if "scan" in h.start:
             # type probably exists if scan exists, but better to check
             if "type" in h.start["scan"]:
-                out_str += f"\t{h.start["scan"]["type"]}"
+                out_str += f"\t{h.start['scan']['type']}"
                 # This is not in every scan type, e.g. peakup
                 if "scan_input" in h.start["scan"]:
-                    out_str += f"\t{h.start["scan"]["scan_input"]}"
+                    out_str += f"\t{h.start['scan']['scan_input']}"
         else:
             # We should probably record what the scan was, e.g. count, scan, rel_scan
-            # What is the proper field that is always valid?
             if "plan_name" in h.start:
-                out_str += f"\t{h.start["plan_name"]}"
+                out_str += f"\t{h.start['plan_name']}"
+            else:
+                out_str += f"\tunknown scan"
         out_str += "\n"
 
         # Write to file

--- a/logscan.py
+++ b/logscan.py
@@ -48,17 +48,28 @@ def logscan_detailed(scanid):
         is_scanid = find_scanid(logfile_path, h.start["scan_id"])
 
     if not is_scanid:
+        # Let's build the string
+        #   Each scan should have a scan ID and UID
+        out_str = f"{h.start["scan_id"]}\t{h.start["uid"]}"
+        #   I don't think the "scan" dictionary is guaranteed with each scan
+        #   I think this is SRX-custom-scan specific
+        if "scan" in h.start:
+            # type probably exists if scan exists, but better to check
+            if "type" in h.start["scan"]:
+                out_str += f"\t{h.start["scan"]["type"]}"
+                # This is not in every scan type, e.g. peakup
+                if "scan_input" in h.start["scan"]:
+                    out_str += f"\t{h.start["scan"]["scan_input"]}"
+        else:
+            # We should probably record what the scan was, e.g. count, scan, rel_scan
+            # What is the proper field that is always valid?
+            if "plan_name" in h.start:
+                out_str += f"\t{h.start["plan_name"]}"
+        out_str += "\n"
+
+        # Write to file
         with open(logfile_path, "a") as userlogf:
-            userlogf.write(
-                str(h.start["scan_id"])
-                + "\t"
-                + str(h.start["uid"])
-                + "\t"
-                + str(h.start["scan"]["type"])
-                + "\t"
-                + str(h.start["scan"]["scan_input"])
-                + "\n"
-            )
+            userlogf.write(out_str)
             logger.info(f"Added {h.start['scan_id']} to the logs")
 
 


### PR DESCRIPTION
Right now, the scan fails during peakup (and probably other scans) so nothing is written to the log file.

This is an attempt to build the string so that the guaranteed values are always there. I am not sure if the "plan_name" value exists for every scan plan, so I hope someone can check this is review.