### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,8 @@
 name: pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NSLS2/srx-workflows/security/code-scanning/1](https://github.com/NSLS2/srx-workflows/security/code-scanning/1)

To fix the problem, explicitly define `permissions` in the workflow so that the `GITHUB_TOKEN` has only the minimal required scopes. For a linting/pre-commit workflow that only checks code and does not modify the repository via the API, `contents: read` is typically sufficient. Defining it at the workflow root will apply to all jobs that do not override it.

The best fix here is to add a `permissions` block at the top level of `.github/workflows/linting.yml`, between the `name:` and `on:` keys, with `contents: read`. This avoids changing any existing job behavior: `actions/checkout` will still be able to read the repository, and the pre-commit action will run as before, but the token will not have unnecessary write access. No imports or additional methods are needed since this is a YAML configuration change only.

Concretely, in `.github/workflows/linting.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (the `name:` line) and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
