### PR TITLE
pass arguments to decorated function

### DIFF
--- a/end_of_run_workflow.py
+++ b/end_of_run_workflow.py
@@ -31,7 +31,7 @@ def slack(func):
     the flow. To keep the naming of workflows consistent, the name of this inner function had to match the expected name.
     """
 
-    def end_of_run_workflow(stop_doc, api_key=None):
+    def end_of_run_workflow(stop_doc, api_key=None, dry_run=False):
         flow_run_name = FlowRunContext.get().flow_run.dict().get("name")
 
         # Load slack credentials that are saved in Prefect.
@@ -52,7 +52,7 @@ def slack(func):
             )
 
         try:
-            result = func(stop_doc)
+            result = func(stop_doc, api_key=api_key, dry_run=dry_run)
 
             # Send a message to mon-prefect if flow-run is successful.
             mon_prefect.notify(


### PR DESCRIPTION
The Slack decorator is not passing through the api_key or dry_run kwargs into the function it wraps, resulting in no API key being used, even if defined in the call to `end_of_run_workflow()`.

Remedy this by adding the kwargs when the wrapped `func()` is called.

Tested by calling `end_of_run_workflow()` from local python.