### PR TITLE
Choose list of streams to analyze instead of removing unwanted streams

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -16,4 +16,4 @@ pillow = ">=12.2.0,<13"
 python-dotenv = ">=1.2.2,<2"
 
 [pypi-dependencies]
-pyxrf = { git = "https://github.com/NSLS2/pyxrf.git", rev="7b7d868" }
+pyxrf = { git = "https://github.com/NSLS2/pyxrf.git", rev="429e7e1" }

--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -145,8 +145,8 @@ def xas_step_exporter(scanid, api_key=None, dry_run=False):
         raise KeyError("SRS not found in data!")
     # Include fluorescence data if present, allow multiple rois
     if "xs" in h.start["detectors"]:
-        if "ROI" in h.start["scan"].keys():
-            roinum = list(h.start["scan"]["ROI"])
+        if "roi_num" in h.start["scan"].keys():
+            roinum = list(h.start["scan"]["roi_num"])
         else:
             roinum = [1]  # if no ROI key found, assume ROI 1
         logger.info(roinum)

--- a/xanes_exporter.py
+++ b/xanes_exporter.py
@@ -240,7 +240,7 @@ def xas_fly_exporter(uid, api_key=None, dry_run=False):
     create_subdir(root)
 
     # Identify scan streams
-    scan_streams = [s for s in hdr if s != "baseline" and "monitor" not in s]
+    scan_streams = [s for s in hdr if "scan" in s]
 
     # ROI information
     roi_num = start_doc["scan"]["roi_num"]


### PR DESCRIPTION
Fixes issue where unwanted vlm-snapshot stream crashes exporter

Tested using scan IDs 188950 and 188954